### PR TITLE
Fix variance divisor and random-selection bias in GP engine

### DIFF
--- a/src/gp/Fitness.java
+++ b/src/gp/Fitness.java
@@ -176,7 +176,11 @@ public class Fitness {
 		BigInteger standardDeviation;
 		if(generation <= MAX_GENERATION_ESTIMATOR) {
 			// special case on initial samples to estimate standard deviation with sub-samples via CLT
-			standardDeviation = Util.sqrt(sumErrorM2Estimator.divide(count.subtract(Constants.I0)));
+			BigInteger varianceDivisor = count.subtract(Constants.I1);
+			if(varianceDivisor.compareTo(Constants.I0) <= 0) {
+				varianceDivisor = Constants.I1;
+			}
+			standardDeviation = Util.sqrt(sumErrorM2Estimator.divide(varianceDivisor));
 			standardDeviation = standardDeviation.divide(Util.sqrt(count));
 		} else {
 			standardDeviation = Util.sqrt(sumErrorM2.divide(BigInteger.valueOf(generation-1)));

--- a/src/gp/Species.java
+++ b/src/gp/Species.java
@@ -170,7 +170,7 @@ public class Species implements Runnable {
 		}
 		for(Program program : listProgram) {
 			Program program1 = program;
-			if(random.nextInt() % PARENT_FACTOR == 0) {
+			if(random.nextInt(PARENT_FACTOR) == 0) {
 				if(listProgramChampion.size() > indexParent) {
 					// use champion instead of parent, same index thus same category
 					program1 = listProgramChampion.get(indexParent);
@@ -178,8 +178,8 @@ public class Species implements Runnable {
 			}
 			for(int indexChild=0; indexChild<MAX_CHILDREN; indexChild++) {
 				Program program2 = null;	// program2==null means mutate
-				if(random.nextInt() % MUTATE_FACTOR == 0) {
-					if(random.nextInt() % PARENT_FACTOR == 0) {
+				if(random.nextInt(MUTATE_FACTOR) == 0) {
+					if(random.nextInt(PARENT_FACTOR) == 0) {
 						if(!listProgramChampion.isEmpty()) {
 							// program2 is champion crossover
 							program2 = listProgramChampion.get(random.nextInt(listProgramChampion.size()));


### PR DESCRIPTION
### Motivation
- Prevent incorrect/unstable variance estimates during early generations by addressing a divisor edge case in the estimator logic.
- Remove subtle bias and sign/overflow artifacts from random branching used for selecting champions/parents and deciding mutation vs. crossover.

### Description
- In `src/gp/Fitness.java` fixed early-generation standard deviation computation to divide by `(count - 1)` semantics with a safe lower bound (`1`) to avoid invalid or zero divisors before taking the sqrt and CLT scaling.
- In `src/gp/Species.java` replaced `random.nextInt() % factor == 0` uses with `random.nextInt(factor) == 0` for both champion/parent selection and mutation/crossover branching to use bounded RNG and remove modulo-on-unbounded-int artifacts.
- Changes are local, preserve original control flow, and tighten statistical correctness and sampling behavior.

### Testing
- Ran repository checks: `git diff -- src/gp/Fitness.java src/gp/Species.java` to verify the diff and `git commit` to persist the changes, both completed successfully.
- No automated unit or integration test suite was executed as part of this patch; recommend adding targeted tests for variance estimation edge-cases and RNG probability frequencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffbaf52a8483278671276220cff1a2)