### PR TITLE
Handle missing javac and improve compilePopulation robustness

### DIFF
--- a/src/gp/Species.java
+++ b/src/gp/Species.java
@@ -202,10 +202,15 @@ public class Species implements Runnable {
 	}
 	
 	public void compilePopulation() { 
-		DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<JavaFileObject>();
+		if(JAVA_COMPILER == null) {
+			LOGGER.severe("Must use JDK (Java bin directory must contain javac)");
+			listProgramPopulation.clear();
+			return;
+		}
 		Iterator<Program> iteratorProgram = listProgramPopulation.iterator(); 
 		while(iteratorProgram.hasNext()) {
 			Program program = iteratorProgram.next();
+			DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<JavaFileObject>();
 			try (StandardJavaFileManager standardJavaFileManager = JAVA_COMPILER.getStandardFileManager(diagnostics, Locale.ENGLISH, null)) {
 				Iterable<Program> javaFileObject = Arrays.asList(program);
 				ProgramClassSimpleJavaFileObject programClassSimpleJavaFileObject = null;
@@ -214,6 +219,7 @@ public class Species implements Runnable {
 				} catch (Exception e) {
 					iteratorProgram.remove();
 					e.printStackTrace();
+					continue;
 				}
 				ProgramForwardingJavaFileManager programForwardingJavaFileManager = new ProgramForwardingJavaFileManager(standardJavaFileManager, programClassSimpleJavaFileObject, program.programClassLoader);
 				CompilationTask compilerTask = JAVA_COMPILER.getTask(null, programForwardingJavaFileManager, diagnostics, null, null, javaFileObject);


### PR DESCRIPTION
### Motivation

- Ensure compilation step fails fast and cleanly when the JDK `javac` is not available.
- Prevent diagnostic cross-contamination between different programs during compilation.
- Avoid proceeding with a null `ProgramClassSimpleJavaFileObject` which could cause runtime errors.

### Description

- Added a check for `JAVA_COMPILER == null` that logs a severe message, clears `listProgramPopulation`, and returns early.
- Moved creation of `DiagnosticCollector<JavaFileObject>` inside the per-program loop so diagnostics are isolated per program.
- Remove the offending `Program` and `continue` the loop when `ProgramClassSimpleJavaFileObject` construction throws, preventing further processing with a null object.

### Testing

- Built the project with a JDK and verified the project compiles successfully.
- Executed the automated test suite and observed all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffbcdc82788327ac8577fc470d92a8)